### PR TITLE
Fixes the error seen if "allowed_dimensions" is not present

### DIFF
--- a/ncdfchecker.py
+++ b/ncdfchecker.py
@@ -222,7 +222,8 @@ def simple_variable_checks(product, constaints, strict=False, logger=None):
         # Catch completely unknown variables - those not in either the
         # constraints or list of allowed dimensions
         if variable not in constraints and \
-                variable not in constraints['allowed_dimensions']:
+                ('allowed_dimensions' in constraints and
+                 variable not in constraints['allowed_dimensions']):
             if strict:
                 logger.error("Unknown variable %s" % variable)
                 errcount += 1

--- a/ncdfchecker.py
+++ b/ncdfchecker.py
@@ -221,9 +221,11 @@ def simple_variable_checks(product, constaints, strict=False, logger=None):
 
         # Catch completely unknown variables - those not in either the
         # constraints or list of allowed dimensions
-        if variable not in constraints and \
-                ('allowed_dimensions' in constraints and
-                 variable not in constraints['allowed_dimensions']):
+        if variable not in constraints:
+            # If variable is an allowed dimension then no error to raise.
+            if 'allowed_dimensions' in constraints and \
+                    variable in constraints['allowed_dimensions']:
+                continue
             if strict:
                 logger.error("Unknown variable %s" % variable)
                 errcount += 1


### PR DESCRIPTION
Closes #4 

Fixes the problem raised in https://github.com/metosfc/ncdfchecker/pull/2#pullrequestreview-213913887 when "allowed_dimensions" is not in the .json file