### PR TITLE
Changed the logic for creating logging object automatically

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ below:
 
 * Andrew Clark (Met Office, UK)
 * Nicola Martin (Met Office, UK)
+* Craig MacLachlan (Met Office, UK)
 
 (All contributors on GitHub are identifiable with email addresses in the
 version control logs or otherwise.)

--- a/ncdfchecker.py
+++ b/ncdfchecker.py
@@ -131,7 +131,7 @@ def check_globals(product, constraints, skip=["short_name"], strict=False,
     errcount = 0
     warncount = 0
 
-    if not logger:
+    if not isinstance(logger, logging.Logger):
         logger = initialise_logger(verbosity=logging.CRITICAL)
 
     for key in constraints['required_global_attributes']:
@@ -206,7 +206,7 @@ def simple_variable_checks(product, constaints, strict=False, logger=None):
     errcount = 0
     warncount = 0
 
-    if not logger:
+    if not isinstance(logger, logging.Logger):
         logger = initialise_logger(verbosity=logging.CRITICAL)
 
     for variable in product.variables:

--- a/test_ncdfchecker.py
+++ b/test_ncdfchecker.py
@@ -283,6 +283,13 @@ class TestProductValidator(unittest.TestCase):
         assert (check_globals(
             self.data, unmet_constraints, strict=True) == (3, 0))
 
+    def test_check_logger_creation(self):
+        """
+        Check the automatic creation of the logger object.
+        """
+        assert (check_globals(
+            self.data, test_constraints, strict=True, logger="a") == (0, 0))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_ncdfchecker.py
+++ b/test_ncdfchecker.py
@@ -285,10 +285,13 @@ class TestProductValidator(unittest.TestCase):
 
     def test_check_logger_creation(self):
         """
-        Check the automatic creation of the logger object.
+        Check the automatic creation of the logger object. The test will 
+        fail if the logging object is not correctly defined.
         """
-        assert (check_globals(
-            self.data, test_constraints, strict=True, logger="a") == (0, 0))
+        try:
+            check_globals(self.data, test_constraints, logger="a")
+        except:
+            self.fail("Unexpected exception.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I thought the testing of the logger existence could be improved. Currently it just checks the boolean nature of the argument (default to None), so you could pass something that wasn't a logging object but evaluates as true and the code would subsequently fail. It's probably unnecessary given the function won't be run outside the script.

I've also added myself to the contributors list.