### PR TITLE
Fix typo and tests for simple variable checking, add name to contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ below:
 * Andrew Clark (Met Office, UK)
 * Nicola Martin (Met Office, UK)
 * Craig MacLachlan (Met Office, UK)
+* Jamie Kettleborough (Met Office, UK)
 
 (All contributors on GitHub are identifiable with email addresses in the
 version control logs or otherwise.)

--- a/ncdfchecker.py
+++ b/ncdfchecker.py
@@ -198,7 +198,7 @@ def check_stepsize(data, stepsize):
     return np.all(steparr == stepsize)
 
 
-def simple_variable_checks(product, constaints, strict=False, logger=None):
+def simple_variable_checks(product, constraints, strict=False, logger=None):
     """
     Carry out simple checks based on variables present in product
     """


### PR DESCRIPTION
Hello Andy,

I've added a couple of tests to increase coverage a bit.  I've also update the contributors list.

One thing I noticed when adding tests is there was a typo in the argument list for `simple_variable_checks`.  I'm not sure why this hasn't caused problems before now.  Do we have local fixes (or did I manage to branch from the wrong place - sorry if I did!)

Do you have any comments/suggestions before merging?

Thanks
Jamie