### PR TITLE
Bugfix to the daily and hourly stepsize checks

### DIFF
--- a/CONFIG_FORMAT.md
+++ b/CONFIG_FORMAT.md
@@ -111,7 +111,7 @@ depending on what that variable is e.g. tas with a leadtime of 6.0 while tauv
 has a leadtime of 24.
 
 To indicate that a particular field is output in monthly or yearly
-intervals, then "month" or "year" must be specified in the
+intervals, then "month" or "years" must be specified in the
 "required_intervals" entry:
 
 **Example**: "sos" : { "required_intervals" : { "leadtime" : "month" } }


### PR DESCRIPTION
Hi @arjclark ,

Can you kindly review these changes? The fix now uses the dateutil.relativedelta module to determine the time intervals for the specified period (days, hours, years). Note that if an interval of 24 hours is given in the json file, then this is equivalent to checking that the interval is 1 day, and I have slightly modified the script to handle this.

For monthly files, I have kept the code that ensures that the month value in the datetime object is incremented by 1. In addition:

1. Added more unit tests to check that step-size calculations still works for 6hr, 12hr and 1 day files,
2. Added a unit test to check that daily files (where the interval of 24 hrs is given in the json file) pass validation checks,
3. Updated check_stepsize tests in ProductValidator class so that the generalised get_period_stepsize function is used (before it wasn't, which is one of the reasons why I think the bug was missed), 
4. Removed redundant imports from test_ncdfchecker.py

Testing:
1. All unit tests pass
2. PEP8 compliant
3. c3s_checks in GloSea suite succeed in pre-PS test mode.

Thanks,

Phil